### PR TITLE
Fix: ConnectionJS for latest version of Mongoose & update Item model

### DIFF
--- a/server/config/connection.js
+++ b/server/config/connection.js
@@ -1,13 +1,7 @@
 const mongoose = require('mongoose');
 
 mongoose.connect(
-  process.env.MONGODB_URI || 'mongodb://localhost/coldOrderFormDB',
-  {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-    useCreateIndex: true,
-    useFindAndModify: false,
-  }
+  process.env.MONGODB_URI || 'mongodb://localhost/coldOrderFormDB'
 );
 
 module.exports = mongoose.connection;

--- a/server/models/Item.js
+++ b/server/models/Item.js
@@ -45,7 +45,7 @@ const itemSchema = new Schema({
         required: true,
     },
 
-    discountedUnitConst: {
+    discountedUnitCost: {
         type: Number,
     },
 

--- a/server/models/Item.js
+++ b/server/models/Item.js
@@ -47,7 +47,6 @@ const itemSchema = new Schema({
 
     discountedUnitConst: {
         type: Number,
-        required: true,
     },
 
     productImageURL: {


### PR DESCRIPTION
See Mongoose docs: https://mongoosejs.com/docs/migrating_to_6.html#no-more-deprecation-warning-options
Not all items have a discounted unit cost so no longer required.